### PR TITLE
Enable WASD camera movement

### DIFF
--- a/src/templates/core/modeller.js
+++ b/src/templates/core/modeller.js
@@ -73,6 +73,9 @@ class Warehouse{
     this._controls = new OrbitControls(
     this._camera, this._threejs.domElement);
     this._controls.target.set(0, 20, 0);
+    // Listen for keyboard events to enable WASD panning
+    this._controls.keys = { LEFT: 'KeyA', UP: 'KeyW', RIGHT: 'KeyD', BOTTOM: 'KeyS' };
+    this._controls.listenToKeyEvents(window);
 
     // Optional: Configure controls for a more FPS-like experience
     this._controls.enableDamping = true; // smooth movement


### PR DESCRIPTION
## Summary
- enable keyboard input for OrbitControls

## Testing
- `pytest -q` *(fails: pyenv pytest command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545393e7b88332966963ce0a5d602a