### PR TITLE
Refactor entity_class manager

### DIFF
--- a/domains/entity_class.py
+++ b/domains/entity_class.py
@@ -8,45 +8,26 @@ import abc
 
 
 class Entity_manager():
-    entity_list = []
-    camera_list = []
-    light_list = []
-    line_list = []
-    figure_list = []
+    entities = {
+        'shape': [],
+        'camera': [],
+        'light': [],
+        'line': [],
+        'figure': []
+    }
 
     def entity_list_append(self, entity_class, entity_type) -> None:
-        if entity_type == 'shape':
-            self.entity_list.append(entity_class)
-        elif entity_type == 'camera':
-            self.camera_list.append(entity_class)
-        elif entity_type == 'light':
-            self.light_list.append(entity_class)
-        elif entity_type == 'line':
-            self.line_list.append(entity_class)
-        elif entity_type == 'figure':
-            self.figure_list.append(entity_class)
+        if entity_type in self.entities:
+            self.entities[entity_type].append(entity_class)
         else:
             print("Error! Wrong entity type!")
 
     def clear_entity_list(self) -> None:
-        for lst in [self.entity_list, self.camera_list, self.light_list, self.line_list, self.figure_list]:
-            for i in lst:
-                del i
+        for lst in self.entities.values():
             lst.clear()
 
     def get_entity_list(self, entity_type):
-        if entity_type == 'shape':
-            return self.entity_list
-        elif entity_type == 'camera':
-            return self.camera_list
-        elif entity_type == 'light':
-            return self.light_list
-        elif entity_type == 'line':
-            return self.line_list
-        elif entity_type == 'figure':
-            return self.figure_list
-        else:
-            return self.entity_list
+        return self.entities.get(entity_type, self.entities['shape'])
 
 
 class Entity(abc.ABC, Entity_manager):
@@ -58,7 +39,11 @@ class Entity(abc.ABC, Entity_manager):
 
     def get_name(self, entity_type):
         entity_number = hash(self)
-        return f"{entity_type}{entity_number}" if entity_type in ['shape', 'camera', 'light', 'line', 'figure'] else 'NaN'
+        return (
+            f"{entity_type}{entity_number}"
+            if entity_type in Entity_manager.entities
+            else 'NaN'
+        )
 
 
 class Line(Entity):
@@ -66,16 +51,16 @@ class Line(Entity):
             self,
             name: str = 'Line',
             color: int = 0xff0000,
-            position1: dict = {'x': 0, 'y': 0, 'z': 0},
-            position2: dict = {'x': 0, 'y': 0, 'z': 0},
+            position1: dict | None = None,
+            position2: dict | None = None,
             material_type: str = 'LineBasicMaterial',
             cast_shadow=True,
             receive_shadow=True
     ) -> None:
         self.geometry_type = 'BufferGeometry'
         self.name = name
-        self.position1 = position1
-        self.position2 = position2
+        self.position1 = position1 or {'x': 0, 'y': 0, 'z': 0}
+        self.position2 = position2 or {'x': 0, 'y': 0, 'z': 0}
         self.material = {'color': color}
         self.material_type = material_type
         self.cast_shadow = cast_shadow
@@ -99,28 +84,28 @@ class Figure(Entity):
             name: str = 'Figure',
             color: int = 0xffffff,
             texture=None,
-            vertices: list = [],
+            vertices: list | None = None,
             vertices_len=3,
-            rotation: dict = {'x': 0, 'y': 0, 'z': 0},
+            rotation: dict | None = None,
             material_type: str = 'MeshBasicMaterial',
             cast_shadow=True,
             receive_shadow=True,
             wireframe=False,
             transparent=False,
-            triangls=[],
+            triangls: list | None = None,
             opacity=0.5
     ) -> None:
         self.geometry_type = 'BufferGeometry'
         self.name = name
-        self.vertices = vertices
+        self.vertices = vertices or []
         self.vertices_len = vertices_len
-        self.rotation = rotation
+        self.rotation = rotation or {'x': 0, 'y': 0, 'z': 0}
         self.material = {'texture': texture} if texture else {
             'color': color, 'wireframe': wireframe, 'transparent': transparent, 'opacity': opacity}
         self.material_type = material_type
         self.cast_shadow = cast_shadow
         self.receive_shadow = receive_shadow
-        self.triangls = triangls
+        self.triangls = triangls or []
 
     def return_dict(self) -> dict:
         return {
@@ -145,8 +130,8 @@ class Box(Entity):
             name: str = 'Box',
             color: int = 0xffffff,
             texture=None,
-            position: dict = {'x': 0, 'y': 0, 'z': 0},
-            rotation: dict = {'x': 0, 'y': 0, 'z': 0},
+            position: dict | None = None,
+            rotation: dict | None = None,
             material_type: str = 'MeshBasicMaterial',
             cast_shadow=True,
             receive_shadow=True
@@ -154,8 +139,8 @@ class Box(Entity):
         self.geometry_type = 'BoxGeometry'
         self.geometry = {'width': width, 'height': height, 'depth': depth}
         self.name = name
-        self.position = position
-        self.rotation = rotation
+        self.position = position or {'x': 0, 'y': 0, 'z': 0}
+        self.rotation = rotation or {'x': 0, 'y': 0, 'z': 0}
         self.material = {'texture': texture} if texture else {'color': color}
         self.material_type = material_type
         self.cast_shadow = cast_shadow
@@ -277,7 +262,7 @@ class Camera(Entity):
             aspect_ratio: str = 'innerWidth / innerHeight',
             clipping_plane_near: float = 0.1,
             clipping_plane_far: float = 10000,
-            position: dict = {'x': -240, 'y': 440, 'z': 140}
+            position: dict | None = None
     ) -> None:
         self.name = name
         self.camera_type = camera_type
@@ -285,7 +270,7 @@ class Camera(Entity):
         self.aspect_ratio = aspect_ratio
         self.clipping_plane_near = clipping_plane_near
         self.clipping_plane_far = clipping_plane_far
-        self.position = position
+        self.position = position or {'x': -240, 'y': 440, 'z': 140}
 
     def return_dict(self) -> dict:
         return self.__dict__
@@ -301,7 +286,7 @@ class OrthographicCamera(Entity):
             near: float = 0.1,
             far: float = 2000,
             name: str = 'OrthographicCamera',
-            position: dict = {'x': 0, 'y': 0, 'z': 100}
+            position: dict | None = None
     ) -> None:
         self.name = name
         self.camera_type = 'OrthographicCamera'
@@ -311,7 +296,7 @@ class OrthographicCamera(Entity):
         self.bottom = bottom
         self.near = near
         self.far = far
-        self.position = position
+        self.position = position or {'x': 0, 'y': 0, 'z': 100}
 
     def return_dict(self) -> dict:
         return self.__dict__
@@ -325,8 +310,8 @@ class Light(Entity):
             color: int = 0xffffff,
             intensity: float = 1.0,
             shadow: dict = None,
-            target_position: dict = {'x': 20, 'y': 100, 'z': 10},
-            position: dict = {'x': 20, 'y': 100, 'z': 10},
+            target_position: dict | None = None,
+            position: dict | None = None,
             cast_shadow=True
     ) -> None:
         self.name = name
@@ -338,8 +323,8 @@ class Light(Entity):
             'mapSize': {'width': 2048, 'height': 2048},
             'camera': {'near': 0.5, 'far': 500, 'left': 100, 'right': -100, 'top': 100, 'bottom': -100}
         }
-        self.target_position = target_position
-        self.position = position
+        self.target_position = target_position or {'x': 20, 'y': 100, 'z': 10}
+        self.position = position or {'x': 20, 'y': 100, 'z': 10}
         self.cast_shadow = cast_shadow
 
     def return_dict(self) -> dict:
@@ -348,12 +333,12 @@ class Light(Entity):
 
 class AmbientLight(Entity):
     def __init__(self, color: int = 0xffffff, intensity: float = 1.0, name: str = 'AmbientLight',
-                 position: dict = {'x': 0, 'y': 0, 'z': 0}) -> None:
+                 position: dict | None = None) -> None:
         self.name = name
         self.light_type = 'AmbientLight'
         self.color = color
         self.intensity = intensity
-        self.position = position
+        self.position = position or {'x': 0, 'y': 0, 'z': 0}
 
     def return_dict(self) -> dict:
         return self.__dict__
@@ -362,13 +347,13 @@ class AmbientLight(Entity):
 class HemisphereLight(Entity):
     def __init__(self, sky_color: int = 0xffffff, ground_color: int = 0x444444,
                  intensity: float = 1.0, name: str = 'HemisphereLight',
-                 position: dict = {'x': 0, 'y': 0, 'z': 0}) -> None:
+                 position: dict | None = None) -> None:
         self.name = name
         self.light_type = 'HemisphereLight'
         self.sky_color = sky_color
         self.ground_color = ground_color
         self.intensity = intensity
-        self.position = position
+        self.position = position or {'x': 0, 'y': 0, 'z': 0}
 
     def return_dict(self) -> dict:
         return self.__dict__
@@ -377,40 +362,24 @@ class HemisphereLight(Entity):
 class Entity_fabric:
     @staticmethod
     def create(entity_type, *args, **kwargs):
-        shape_dict = {
-            'box': Box, 'sphere': Sphere, 'plane': Plane,
-            'cylinder': Cylinder, 'cone': Cone, 'torus': Torus
-        }
-        camera_dict = {
-            'camera': Camera, 'ortho_camera': OrthographicCamera
-        }
-        light_dict = {
-            'light': Light, 'ambient': AmbientLight, 'hemisphere': HemisphereLight
+        mapping = {
+            'box': (Box, 'shape'),
+            'sphere': (Sphere, 'shape'),
+            'plane': (Plane, 'shape'),
+            'cylinder': (Cylinder, 'shape'),
+            'cone': (Cone, 'shape'),
+            'torus': (Torus, 'shape'),
+            'camera': (Camera, 'camera'),
+            'ortho_camera': (OrthographicCamera, 'camera'),
+            'light': (Light, 'light'),
+            'ambient': (AmbientLight, 'light'),
+            'hemisphere': (HemisphereLight, 'light'),
+            'line': (Line, 'line'),
+            'figure': (Figure, 'figure'),
         }
 
-        if entity_type in shape_dict:
-            entity = shape_dict[entity_type](*args, **kwargs)
-            entity.entity_list_append(entity, 'shape')
-            entity.name = entity.get_name('shape')
-        elif entity_type in camera_dict:
-            entity = camera_dict[entity_type](*args, **kwargs)
-            entity.entity_list_append(entity, 'camera')
-            entity.name = entity.get_name('camera')
-        elif entity_type in light_dict:
-            entity = light_dict[entity_type](*args, **kwargs)
-            entity.entity_list_append(entity, 'light')
-            entity.name = entity.get_name('light')
-        elif entity_type == 'line':
-            entity = Line(*args, **kwargs)
-            entity.entity_list_append(entity, 'line')
-            entity.name = entity.get_name('line')
-        elif entity_type == 'figure':
-            entity = Figure(*args, **kwargs)
-            entity.entity_list_append(entity, 'figure')
-            entity.name = entity.get_name('figure')
-        else:
-            entity = Box(*args, **kwargs)
-            entity.entity_list_append(entity, 'shape')
-            entity.name = entity.get_name('shape')
-
+        entity_cls, ent_type = mapping.get(entity_type, (Box, 'shape'))
+        entity = entity_cls(*args, **kwargs)
+        entity.entity_list_append(entity, ent_type)
+        entity.name = entity.get_name(ent_type)
         return entity


### PR DESCRIPTION
## Summary
- simplify entity manager with a dictionary of lists
- avoid mutable default arguments in entity constructors
- streamline factory creation logic

## Testing
- `python3 -m py_compile domains/entity_class.py`
- `ruff domains/entity_class.py` *(fails: command not found)*
- `black domains/entity_class.py --check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d19084c48332991266c6e032090b