### PR TITLE
Add WebGL availability check

### DIFF
--- a/include/modeller.js
+++ b/include/modeller.js
@@ -4,12 +4,30 @@ import { GLTFLoader } from "https://cdn.jsdelivr.net/npm/three@0.121.1/examples/
 import { Earcut } from "https://cdn.jsdelivr.net/npm/three@0.121.1/src/extras/Earcut.js";
 import { Timer } from 'https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/misc/Timer.js';
 
+function webglAvailable() {
+  try {
+    const canvas = document.createElement('canvas');
+    return !!window.WebGLRenderingContext && (
+      canvas.getContext('webgl') || canvas.getContext('experimental-webgl')
+    );
+  } catch (e) {
+    return false;
+  }
+}
+
 var timer = new Timer();
 var cur_tick;
 var last_tick = 0;
 
 class Warehouse{
   constructor(Warehouse) {
+    if (!webglAvailable()) {
+      console.error('WebGL not supported');
+      const message = document.createElement('div');
+      message.textContent = 'WebGL not supported in this environment.';
+      document.getElementById('app').appendChild(message);
+      return;
+    }
     this._Initialize();
   }
 

--- a/src/templates/core/modeller.js
+++ b/src/templates/core/modeller.js
@@ -7,6 +7,17 @@ import { WS } from './static/js/websocket.js';
 import { PositionalRadio } from './static/js/positional_radio.js';
 import dat from "https://cdn.skypack.dev/dat.gui";
 
+function webglAvailable() {
+  try {
+    const canvas = document.createElement('canvas');
+    return !!window.WebGLRenderingContext && (
+      canvas.getContext('webgl') || canvas.getContext('experimental-webgl')
+    );
+  } catch (e) {
+    return false;
+  }
+}
+
 
 var camera_position;
 
@@ -35,6 +46,13 @@ const _WS = new WS();
 
 class Warehouse{
   constructor(Warehouse) {
+    if (!webglAvailable()) {
+      console.error('WebGL not supported');
+      const message = document.createElement('div');
+      message.textContent = 'WebGL not supported in this environment.';
+      document.getElementById('app').appendChild(message);
+      return;
+    }
     this._Initialize();
   }
 


### PR DESCRIPTION
## Summary
- detect if WebGL is available before initializing renderer
- warn user when WebGL context cannot be created

## Testing
- `node --version`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_6856b6b377a883328fe77d2666e995d5