### PR TITLE
Fix bare specifiers for three.js

### DIFF
--- a/src/static/js/GLTFLoader.js
+++ b/src/static/js/GLTFLoader.js
@@ -61,7 +61,7 @@ import {
 	Vector3,
 	VectorKeyframeTrack,
 	SRGBColorSpace
-} from 'three';
+} from './three.module.js';
 import { toTrianglesDrawMode } from '../utils/BufferGeometryUtils.js';
 
 class GLTFLoader extends Loader {

--- a/src/static/js/OrbitControls.js
+++ b/src/static/js/OrbitControls.js
@@ -6,7 +6,7 @@ import {
 	TOUCH,
 	Vector2,
 	Vector3
-} from 'three';
+} from './three.module.js';
 
 // OrbitControls performs orbiting, dollying (zooming), and panning.
 // Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).


### PR DESCRIPTION
## Summary
- update GLTFLoader.js to import three.js via relative path
- update OrbitControls.js to import three.js via relative path

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6856bd58f5e88332a050f12f9d869367