### PR TITLE
Fix BufferGeometryUtils import path

### DIFF
--- a/src/static/utils/BufferGeometryUtils.js
+++ b/src/static/utils/BufferGeometryUtils.js
@@ -9,7 +9,7 @@ import {
 	TriangleStripDrawMode,
 	TrianglesDrawMode,
 	Vector3,
-} from 'three';
+} from '../js/three.module.js';
 
 /**
  * @module BufferGeometryUtils


### PR DESCRIPTION
## Summary
- fix import path in BufferGeometryUtils to use local copy of Three.js

## Testing
- `grep -R "three.module.js" -n src | head`


------
https://chatgpt.com/codex/tasks/task_e_6856bfc1f588833282491bfeec620941