### PR TITLE
Add Text3D support

### DIFF
--- a/domains/entity_class.py
+++ b/domains/entity_class.py
@@ -8,14 +8,8 @@ import abc
 import uuid
 
 
-class Entity_manager():
-    entities = {
-        'shape': [],
-        'camera': [],
-        'light': [],
-        'line': [],
-        'figure': []
-    }
+class Entity_manager:
+    entities = {"shape": [], "camera": [], "light": [], "line": [], "figure": []}
 
     def entity_list_append(self, entity_class, entity_type) -> None:
         if entity_type in self.entities:
@@ -28,7 +22,7 @@ class Entity_manager():
             lst.clear()
 
     def get_entity_list(self, entity_type):
-        return self.entities.get(entity_type, self.entities['shape'])
+        return self.entities.get(entity_type, self.entities["shape"])
 
 
 class Entity(abc.ABC, Entity_manager):
@@ -36,7 +30,7 @@ class Entity(abc.ABC, Entity_manager):
 
     def __init__(self, scale: dict | None = None, visible: bool = True) -> None:
         self.uuid = str(uuid.uuid4())
-        self.scale = scale or {'x': 1, 'y': 1, 'z': 1}
+        self.scale = scale or {"x": 1, "y": 1, "z": 1}
         self.visible = visible
 
     @abc.abstractmethod
@@ -48,75 +42,83 @@ class Entity(abc.ABC, Entity_manager):
         return (
             f"{entity_type}{entity_number}"
             if entity_type in Entity_manager.entities
-            else 'NaN'
+            else "NaN"
         )
 
 
 class Line(Entity):
     def __init__(
-            self,
-            name: str = 'Line',
-            color: int = 0xff0000,
-            position1: dict | None = None,
-            position2: dict | None = None,
-            material_type: str = 'LineBasicMaterial',
-            cast_shadow=True,
-            receive_shadow=True,
-            scale: dict | None = None,
-            visible: bool = True
+        self,
+        name: str = "Line",
+        color: int = 0xFF0000,
+        position1: dict | None = None,
+        position2: dict | None = None,
+        material_type: str = "LineBasicMaterial",
+        cast_shadow=True,
+        receive_shadow=True,
+        scale: dict | None = None,
+        visible: bool = True,
     ) -> None:
         super().__init__(scale=scale, visible=visible)
-        self.geometry_type = 'BufferGeometry'
+        self.geometry_type = "BufferGeometry"
         self.name = name
-        self.position1 = position1 or {'x': 0, 'y': 0, 'z': 0}
-        self.position2 = position2 or {'x': 0, 'y': 0, 'z': 0}
-        self.material = {'color': color}
+        self.position1 = position1 or {"x": 0, "y": 0, "z": 0}
+        self.position2 = position2 or {"x": 0, "y": 0, "z": 0}
+        self.material = {"color": color}
         self.material_type = material_type
         self.cast_shadow = cast_shadow
         self.receive_shadow = receive_shadow
 
     def return_dict(self) -> dict:
         return {
-            'material_type': self.material_type,
-            'geometry_type': self.geometry_type,
-            'material': self.material,
-            'position1': self.position1,
-            'position2': self.position2,
-            'scale': self.scale,
-            'visible': self.visible,
-            'uuid': self.uuid,
-            'castShadow': self.cast_shadow,
-            'receiveShadow': self.receive_shadow
+            "material_type": self.material_type,
+            "geometry_type": self.geometry_type,
+            "material": self.material,
+            "position1": self.position1,
+            "position2": self.position2,
+            "scale": self.scale,
+            "visible": self.visible,
+            "uuid": self.uuid,
+            "castShadow": self.cast_shadow,
+            "receiveShadow": self.receive_shadow,
         }
 
 
 class Figure(Entity):
     def __init__(
-            self,
-            name: str = 'Figure',
-            color: int = 0xffffff,
-            texture=None,
-            vertices: list | None = None,
-            vertices_len=3,
-            rotation: dict | None = None,
-            material_type: str = 'MeshBasicMaterial',
-            cast_shadow=True,
-            receive_shadow=True,
-            wireframe=False,
-            transparent=False,
-            triangls: list | None = None,
-            opacity=0.5,
-            scale: dict | None = None,
-            visible: bool = True
+        self,
+        name: str = "Figure",
+        color: int = 0xFFFFFF,
+        texture=None,
+        vertices: list | None = None,
+        vertices_len=3,
+        rotation: dict | None = None,
+        material_type: str = "MeshBasicMaterial",
+        cast_shadow=True,
+        receive_shadow=True,
+        wireframe=False,
+        transparent=False,
+        triangls: list | None = None,
+        opacity=0.5,
+        scale: dict | None = None,
+        visible: bool = True,
     ) -> None:
         super().__init__(scale=scale, visible=visible)
-        self.geometry_type = 'BufferGeometry'
+        self.geometry_type = "BufferGeometry"
         self.name = name
         self.vertices = vertices or []
         self.vertices_len = vertices_len
-        self.rotation = rotation or {'x': 0, 'y': 0, 'z': 0}
-        self.material = {'texture': texture} if texture else {
-            'color': color, 'wireframe': wireframe, 'transparent': transparent, 'opacity': opacity}
+        self.rotation = rotation or {"x": 0, "y": 0, "z": 0}
+        self.material = (
+            {"texture": texture}
+            if texture
+            else {
+                "color": color,
+                "wireframe": wireframe,
+                "transparent": transparent,
+                "opacity": opacity,
+            }
+        )
         self.material_type = material_type
         self.cast_shadow = cast_shadow
         self.receive_shadow = receive_shadow
@@ -124,213 +126,259 @@ class Figure(Entity):
 
     def return_dict(self) -> dict:
         return {
-            'material_type': self.material_type,
-            'geometry_type': self.geometry_type,
-            'material': self.material,
-            'vertices': self.vertices,
-            'vertices_len': self.vertices_len,
-            'rotation': self.rotation,
-            'scale': self.scale,
-            'visible': self.visible,
-            'uuid': self.uuid,
-            'castShadow': self.cast_shadow,
-            'receiveShadow': self.receive_shadow,
-            'triangls': self.triangls
+            "material_type": self.material_type,
+            "geometry_type": self.geometry_type,
+            "material": self.material,
+            "vertices": self.vertices,
+            "vertices_len": self.vertices_len,
+            "rotation": self.rotation,
+            "scale": self.scale,
+            "visible": self.visible,
+            "uuid": self.uuid,
+            "castShadow": self.cast_shadow,
+            "receiveShadow": self.receive_shadow,
+            "triangls": self.triangls,
         }
 
 
 class Box(Entity):
     def __init__(
-            self,
-            width: float,
-            height: float,
-            depth: float,
-            name: str = 'Box',
-            color: int = 0xffffff,
-            texture=None,
-            position: dict | None = None,
-            rotation: dict | None = None,
-            material_type: str = 'MeshBasicMaterial',
-            cast_shadow=True,
-            receive_shadow=True,
-            scale: dict | None = None,
-            visible: bool = True
+        self,
+        width: float,
+        height: float,
+        depth: float,
+        name: str = "Box",
+        color: int = 0xFFFFFF,
+        texture=None,
+        position: dict | None = None,
+        rotation: dict | None = None,
+        material_type: str = "MeshBasicMaterial",
+        cast_shadow=True,
+        receive_shadow=True,
+        scale: dict | None = None,
+        visible: bool = True,
     ) -> None:
         super().__init__(scale=scale, visible=visible)
-        self.geometry_type = 'BoxGeometry'
-        self.geometry = {'width': width, 'height': height, 'depth': depth}
+        self.geometry_type = "BoxGeometry"
+        self.geometry = {"width": width, "height": height, "depth": depth}
         self.name = name
-        self.position = position or {'x': 0, 'y': 0, 'z': 0}
-        self.rotation = rotation or {'x': 0, 'y': 0, 'z': 0}
-        self.material = {'texture': texture} if texture else {'color': color}
+        self.position = position or {"x": 0, "y": 0, "z": 0}
+        self.rotation = rotation or {"x": 0, "y": 0, "z": 0}
+        self.material = {"texture": texture} if texture else {"color": color}
         self.material_type = material_type
         self.cast_shadow = cast_shadow
         self.receive_shadow = receive_shadow
 
     def return_dict(self) -> dict:
         return {
-            'material_type': self.material_type,
-            'geometry_type': self.geometry_type,
-            'geometry': self.geometry,
-            'material': self.material,
-            'position': self.position,
-            'rotation': self.rotation,
-            'scale': self.scale,
-            'visible': self.visible,
-            'uuid': self.uuid,
-            'castShadow': self.cast_shadow,
-            'receiveShadow': self.receive_shadow
+            "material_type": self.material_type,
+            "geometry_type": self.geometry_type,
+            "geometry": self.geometry,
+            "material": self.material,
+            "position": self.position,
+            "rotation": self.rotation,
+            "scale": self.scale,
+            "visible": self.visible,
+            "uuid": self.uuid,
+            "castShadow": self.cast_shadow,
+            "receiveShadow": self.receive_shadow,
         }
 
 
 class Sphere(Box):
     def __init__(
-            self,
-            radius: float,
-            widthSegments: int,
-            heightSegments: int,
-            **kwargs
+        self, radius: float, widthSegments: int, heightSegments: int, **kwargs
     ):
         super().__init__(0, 0, 0, **kwargs)
-        self.geometry_type = 'SphereGeometry'
+        self.geometry_type = "SphereGeometry"
         self.geometry = {
-            'radius': radius,
-            'widthSegments': widthSegments,
-            'heightSegments': heightSegments
+            "radius": radius,
+            "widthSegments": widthSegments,
+            "heightSegments": heightSegments,
         }
 
 
 class Plane(Box):
-    def __init__(
-            self,
-            width: float,
-            height: float,
-            **kwargs
-    ):
+    def __init__(self, width: float, height: float, **kwargs):
         super().__init__(width, height, 0, **kwargs)
-        self.geometry_type = 'PlaneGeometry'
-        self.geometry = {'width': width, 'height': height}
+        self.geometry_type = "PlaneGeometry"
+        self.geometry = {"width": width, "height": height}
 
 
 class Cylinder(Box):
     def __init__(
-            self,
-            radiusTop: float,
-            radiusBottom: float,
-            height: float,
-            radialSegments: int = 8,
-            heightSegments: int = 1,
-            openEnded: bool = False,
-            **kwargs
+        self,
+        radiusTop: float,
+        radiusBottom: float,
+        height: float,
+        radialSegments: int = 8,
+        heightSegments: int = 1,
+        openEnded: bool = False,
+        **kwargs,
     ):
         super().__init__(0, 0, 0, **kwargs)
-        self.geometry_type = 'CylinderGeometry'
+        self.geometry_type = "CylinderGeometry"
         self.geometry = {
-            'radiusTop': radiusTop,
-            'radiusBottom': radiusBottom,
-            'height': height,
-            'radialSegments': radialSegments,
-            'heightSegments': heightSegments,
-            'openEnded': openEnded
+            "radiusTop": radiusTop,
+            "radiusBottom": radiusBottom,
+            "height": height,
+            "radialSegments": radialSegments,
+            "heightSegments": heightSegments,
+            "openEnded": openEnded,
         }
 
 
 class Cone(Box):
     def __init__(
-            self,
-            radius: float,
-            height: float,
-            radialSegments: int = 8,
-            heightSegments: int = 1,
-            openEnded: bool = False,
-            **kwargs
+        self,
+        radius: float,
+        height: float,
+        radialSegments: int = 8,
+        heightSegments: int = 1,
+        openEnded: bool = False,
+        **kwargs,
     ):
         super().__init__(0, 0, 0, **kwargs)
-        self.geometry_type = 'ConeGeometry'
+        self.geometry_type = "ConeGeometry"
         self.geometry = {
-            'radius': radius,
-            'height': height,
-            'radialSegments': radialSegments,
-            'heightSegments': heightSegments,
-            'openEnded': openEnded
+            "radius": radius,
+            "height": height,
+            "radialSegments": radialSegments,
+            "heightSegments": heightSegments,
+            "openEnded": openEnded,
         }
 
 
 class Torus(Box):
     def __init__(
-            self,
-            radius: float,
-            tube: float,
-            radialSegments: int = 16,
-            tubularSegments: int = 100,
-            arc: float = 6.283185307179586,
-            **kwargs
+        self,
+        radius: float,
+        tube: float,
+        radialSegments: int = 16,
+        tubularSegments: int = 100,
+        arc: float = 6.283185307179586,
+        **kwargs,
     ):
         super().__init__(0, 0, 0, **kwargs)
-        self.geometry_type = 'TorusGeometry'
+        self.geometry_type = "TorusGeometry"
         self.geometry = {
-            'radius': radius,
-            'tube': tube,
-            'radialSegments': radialSegments,
-            'tubularSegments': tubularSegments,
-            'arc': arc
+            "radius": radius,
+            "tube": tube,
+            "radialSegments": radialSegments,
+            "tubularSegments": tubularSegments,
+            "arc": arc,
         }
 
 
 class Circle(Box):
     def __init__(
-            self,
-            radius: float,
-            segments: int = 32,
-            thetaStart: float = 0.0,
-            thetaLength: float = 6.283185307179586,
-            **kwargs
+        self,
+        radius: float,
+        segments: int = 32,
+        thetaStart: float = 0.0,
+        thetaLength: float = 6.283185307179586,
+        **kwargs,
     ):
         super().__init__(0, 0, 0, **kwargs)
-        self.geometry_type = 'CircleGeometry'
+        self.geometry_type = "CircleGeometry"
         self.geometry = {
-            'radius': radius,
-            'segments': segments,
-            'thetaStart': thetaStart,
-            'thetaLength': thetaLength
+            "radius": radius,
+            "segments": segments,
+            "thetaStart": thetaStart,
+            "thetaLength": thetaLength,
         }
 
 
 class Ring(Box):
     def __init__(
-            self,
-            innerRadius: float,
-            outerRadius: float,
-            thetaSegments: int = 32,
-            phiSegments: int = 1,
-            thetaStart: float = 0.0,
-            thetaLength: float = 6.283185307179586,
-            **kwargs
+        self,
+        innerRadius: float,
+        outerRadius: float,
+        thetaSegments: int = 32,
+        phiSegments: int = 1,
+        thetaStart: float = 0.0,
+        thetaLength: float = 6.283185307179586,
+        **kwargs,
     ):
         super().__init__(0, 0, 0, **kwargs)
-        self.geometry_type = 'RingGeometry'
+        self.geometry_type = "RingGeometry"
         self.geometry = {
-            'innerRadius': innerRadius,
-            'outerRadius': outerRadius,
-            'thetaSegments': thetaSegments,
-            'phiSegments': phiSegments,
-            'thetaStart': thetaStart,
-            'thetaLength': thetaLength
+            "innerRadius": innerRadius,
+            "outerRadius": outerRadius,
+            "thetaSegments": thetaSegments,
+            "phiSegments": phiSegments,
+            "thetaStart": thetaStart,
+            "thetaLength": thetaLength,
+        }
+
+
+class Text3D(Entity):
+    def __init__(
+        self,
+        text: str,
+        size: float = 10,
+        height: float = 2,
+        curveSegments: int = 12,
+        bevelEnabled: bool = False,
+        bevelThickness: float = 1,
+        bevelSize: float = 0.5,
+        bevelOffset: float = 0,
+        bevelSegments: int = 3,
+        font: str = "helvetiker",
+        name: str = "Text3D",
+        color: int = 0xFFFFFF,
+        position: dict = {"x": 0, "y": 0, "z": 0},
+        rotation: dict = {"x": 0, "y": 0, "z": 0},
+        material_type: str = "MeshBasicMaterial",
+        cast_shadow: bool = True,
+        receive_shadow: bool = True,
+    ):
+        self.geometry_type = "TextGeometry"
+        self.geometry = {
+            "text": text,
+            "size": size,
+            "height": height,
+            "curveSegments": curveSegments,
+            "bevelEnabled": bevelEnabled,
+            "bevelThickness": bevelThickness,
+            "bevelSize": bevelSize,
+            "bevelOffset": bevelOffset,
+            "bevelSegments": bevelSegments,
+            "font": font,
+        }
+        self.name = name
+        self.position = position
+        self.rotation = rotation
+        self.material = {"color": color}
+        self.material_type = material_type
+        self.cast_shadow = cast_shadow
+        self.receive_shadow = receive_shadow
+
+    def return_dict(self) -> dict:
+        return {
+            "geometry_type": self.geometry_type,
+            "geometry": self.geometry,
+            "material": self.material,
+            "material_type": self.material_type,
+            "position": self.position,
+            "rotation": self.rotation,
+            "castShadow": self.cast_shadow,
+            "receiveShadow": self.receive_shadow,
         }
 
 
 class Camera(Entity):
     def __init__(
-            self,
-            name: str = 'Camera',
-            camera_type: str = 'PerspectiveCamera',
-            fild_of_view: int = 75,
-            aspect_ratio: str = 'innerWidth / innerHeight',
-            clipping_plane_near: float = 0.1,
-            clipping_plane_far: float = 10000,
-            position: dict | None = None,
-            scale: dict | None = None,
-            visible: bool = True
+        self,
+        name: str = "Camera",
+        camera_type: str = "PerspectiveCamera",
+        fild_of_view: int = 75,
+        aspect_ratio: str = "innerWidth / innerHeight",
+        clipping_plane_near: float = 0.1,
+        clipping_plane_far: float = 10000,
+        position: dict | None = None,
+        scale: dict | None = None,
+        visible: bool = True,
     ) -> None:
         super().__init__(scale=scale, visible=visible)
         self.name = name
@@ -339,7 +387,7 @@ class Camera(Entity):
         self.aspect_ratio = aspect_ratio
         self.clipping_plane_near = clipping_plane_near
         self.clipping_plane_far = clipping_plane_far
-        self.position = position or {'x': -240, 'y': 440, 'z': 140}
+        self.position = position or {"x": -240, "y": 440, "z": 140}
 
     def return_dict(self) -> dict:
         return self.__dict__
@@ -347,28 +395,28 @@ class Camera(Entity):
 
 class OrthographicCamera(Entity):
     def __init__(
-            self,
-            left: float,
-            right: float,
-            top: float,
-            bottom: float,
-            near: float = 0.1,
-            far: float = 2000,
-            name: str = 'OrthographicCamera',
-            position: dict | None = None,
-            scale: dict | None = None,
-            visible: bool = True
+        self,
+        left: float,
+        right: float,
+        top: float,
+        bottom: float,
+        near: float = 0.1,
+        far: float = 2000,
+        name: str = "OrthographicCamera",
+        position: dict | None = None,
+        scale: dict | None = None,
+        visible: bool = True,
     ) -> None:
         super().__init__(scale=scale, visible=visible)
         self.name = name
-        self.camera_type = 'OrthographicCamera'
+        self.camera_type = "OrthographicCamera"
         self.left = left
         self.right = right
         self.top = top
         self.bottom = bottom
         self.near = near
         self.far = far
-        self.position = position or {'x': 0, 'y': 0, 'z': 100}
+        self.position = position or {"x": 0, "y": 0, "z": 100}
 
     def return_dict(self) -> dict:
         return self.__dict__
@@ -376,17 +424,17 @@ class OrthographicCamera(Entity):
 
 class Light(Entity):
     def __init__(
-            self,
-            name: str = 'Light',
-            light_type: str = 'DirectionalLight',
-            color: int = 0xffffff,
-            intensity: float = 1.0,
-            shadow: dict = None,
-            target_position: dict | None = None,
-            position: dict | None = None,
-            cast_shadow=True,
-            scale: dict | None = None,
-            visible: bool = True
+        self,
+        name: str = "Light",
+        light_type: str = "DirectionalLight",
+        color: int = 0xFFFFFF,
+        intensity: float = 1.0,
+        shadow: dict = None,
+        target_position: dict | None = None,
+        position: dict | None = None,
+        cast_shadow=True,
+        scale: dict | None = None,
+        visible: bool = True,
     ) -> None:
         super().__init__(scale=scale, visible=visible)
         self.name = name
@@ -394,12 +442,19 @@ class Light(Entity):
         self.intensity = intensity
         self.light_type = light_type
         self.shadow = shadow or {
-            'bias': -0.001,
-            'mapSize': {'width': 2048, 'height': 2048},
-            'camera': {'near': 0.5, 'far': 500, 'left': 100, 'right': -100, 'top': 100, 'bottom': -100}
+            "bias": -0.001,
+            "mapSize": {"width": 2048, "height": 2048},
+            "camera": {
+                "near": 0.5,
+                "far": 500,
+                "left": 100,
+                "right": -100,
+                "top": 100,
+                "bottom": -100,
+            },
         }
-        self.target_position = target_position or {'x': 20, 'y': 100, 'z': 10}
-        self.position = position or {'x': 20, 'y': 100, 'z': 10}
+        self.target_position = target_position or {"x": 20, "y": 100, "z": 10}
+        self.position = position or {"x": 20, "y": 100, "z": 10}
         self.cast_shadow = cast_shadow
 
     def return_dict(self) -> dict:
@@ -407,34 +462,44 @@ class Light(Entity):
 
 
 class AmbientLight(Entity):
-    def __init__(self, color: int = 0xffffff, intensity: float = 1.0, name: str = 'AmbientLight',
-                 position: dict | None = None,
-                 scale: dict | None = None,
-                 visible: bool = True) -> None:
+    def __init__(
+        self,
+        color: int = 0xFFFFFF,
+        intensity: float = 1.0,
+        name: str = "AmbientLight",
+        position: dict | None = None,
+        scale: dict | None = None,
+        visible: bool = True,
+    ) -> None:
         super().__init__(scale=scale, visible=visible)
         self.name = name
-        self.light_type = 'AmbientLight'
+        self.light_type = "AmbientLight"
         self.color = color
         self.intensity = intensity
-        self.position = position or {'x': 0, 'y': 0, 'z': 0}
+        self.position = position or {"x": 0, "y": 0, "z": 0}
 
     def return_dict(self) -> dict:
         return self.__dict__
 
 
 class HemisphereLight(Entity):
-    def __init__(self, sky_color: int = 0xffffff, ground_color: int = 0x444444,
-                 intensity: float = 1.0, name: str = 'HemisphereLight',
-                 position: dict | None = None,
-                 scale: dict | None = None,
-                 visible: bool = True) -> None:
+    def __init__(
+        self,
+        sky_color: int = 0xFFFFFF,
+        ground_color: int = 0x444444,
+        intensity: float = 1.0,
+        name: str = "HemisphereLight",
+        position: dict | None = None,
+        scale: dict | None = None,
+        visible: bool = True,
+    ) -> None:
         super().__init__(scale=scale, visible=visible)
         self.name = name
-        self.light_type = 'HemisphereLight'
+        self.light_type = "HemisphereLight"
         self.sky_color = sky_color
         self.ground_color = ground_color
         self.intensity = intensity
-        self.position = position or {'x': 0, 'y': 0, 'z': 0}
+        self.position = position or {"x": 0, "y": 0, "z": 0}
 
     def return_dict(self) -> dict:
         return self.__dict__
@@ -442,31 +507,31 @@ class HemisphereLight(Entity):
 
 class PointLight(Entity):
     def __init__(
-            self,
-            name: str = 'PointLight',
-            color: int = 0xffffff,
-            intensity: float = 1.0,
-            distance: float = 0.0,
-            decay: float = 2.0,
-            shadow: dict | None = None,
-            position: dict | None = None,
-            cast_shadow=True,
-            scale: dict | None = None,
-            visible: bool = True
+        self,
+        name: str = "PointLight",
+        color: int = 0xFFFFFF,
+        intensity: float = 1.0,
+        distance: float = 0.0,
+        decay: float = 2.0,
+        shadow: dict | None = None,
+        position: dict | None = None,
+        cast_shadow=True,
+        scale: dict | None = None,
+        visible: bool = True,
     ) -> None:
         super().__init__(scale=scale, visible=visible)
         self.name = name
-        self.light_type = 'PointLight'
+        self.light_type = "PointLight"
         self.color = color
         self.intensity = intensity
         self.distance = distance
         self.decay = decay
         self.shadow = shadow or {
-            'bias': -0.001,
-            'mapSize': {'width': 1024, 'height': 1024},
-            'camera': {'near': 0.5, 'far': 500}
+            "bias": -0.001,
+            "mapSize": {"width": 1024, "height": 1024},
+            "camera": {"near": 0.5, "far": 500},
         }
-        self.position = position or {'x': 0, 'y': 0, 'z': 0}
+        self.position = position or {"x": 0, "y": 0, "z": 0}
         self.cast_shadow = cast_shadow
 
     def return_dict(self) -> dict:
@@ -475,24 +540,24 @@ class PointLight(Entity):
 
 class SpotLight(Entity):
     def __init__(
-            self,
-            name: str = 'SpotLight',
-            color: int = 0xffffff,
-            intensity: float = 1.0,
-            distance: float = 0.0,
-            angle: float = 1.047198,
-            penumbra: float = 0.0,
-            decay: float = 2.0,
-            shadow: dict | None = None,
-            target_position: dict | None = None,
-            position: dict | None = None,
-            cast_shadow=True,
-            scale: dict | None = None,
-            visible: bool = True
+        self,
+        name: str = "SpotLight",
+        color: int = 0xFFFFFF,
+        intensity: float = 1.0,
+        distance: float = 0.0,
+        angle: float = 1.047198,
+        penumbra: float = 0.0,
+        decay: float = 2.0,
+        shadow: dict | None = None,
+        target_position: dict | None = None,
+        position: dict | None = None,
+        cast_shadow=True,
+        scale: dict | None = None,
+        visible: bool = True,
     ) -> None:
         super().__init__(scale=scale, visible=visible)
         self.name = name
-        self.light_type = 'SpotLight'
+        self.light_type = "SpotLight"
         self.color = color
         self.intensity = intensity
         self.distance = distance
@@ -500,12 +565,12 @@ class SpotLight(Entity):
         self.penumbra = penumbra
         self.decay = decay
         self.shadow = shadow or {
-            'bias': -0.001,
-            'mapSize': {'width': 1024, 'height': 1024},
-            'camera': {'near': 0.5, 'far': 500, 'fov': 30}
+            "bias": -0.001,
+            "mapSize": {"width": 1024, "height": 1024},
+            "camera": {"near": 0.5, "far": 500, "fov": 30},
         }
-        self.target_position = target_position or {'x': 0, 'y': 0, 'z': 0}
-        self.position = position or {'x': 0, 'y': 0, 'z': 0}
+        self.target_position = target_position or {"x": 0, "y": 0, "z": 0}
+        self.position = position or {"x": 0, "y": 0, "z": 0}
         self.cast_shadow = cast_shadow
 
     def return_dict(self) -> dict:
@@ -516,26 +581,27 @@ class Entity_fabric:
     @staticmethod
     def create(entity_type, *args, **kwargs):
         mapping = {
-            'box': (Box, 'shape'),
-            'sphere': (Sphere, 'shape'),
-            'plane': (Plane, 'shape'),
-            'cylinder': (Cylinder, 'shape'),
-            'cone': (Cone, 'shape'),
-            'torus': (Torus, 'shape'),
-            'circle': (Circle, 'shape'),
-            'ring': (Ring, 'shape'),
-            'camera': (Camera, 'camera'),
-            'ortho_camera': (OrthographicCamera, 'camera'),
-            'light': (Light, 'light'),
-            'point_light': (PointLight, 'light'),
-            'spot_light': (SpotLight, 'light'),
-            'ambient': (AmbientLight, 'light'),
-            'hemisphere': (HemisphereLight, 'light'),
-            'line': (Line, 'line'),
-            'figure': (Figure, 'figure'),
+            "box": (Box, "shape"),
+            "sphere": (Sphere, "shape"),
+            "plane": (Plane, "shape"),
+            "cylinder": (Cylinder, "shape"),
+            "cone": (Cone, "shape"),
+            "torus": (Torus, "shape"),
+            "circle": (Circle, "shape"),
+            "ring": (Ring, "shape"),
+            "text3d": (Text3D, "shape"),
+            "camera": (Camera, "camera"),
+            "ortho_camera": (OrthographicCamera, "camera"),
+            "light": (Light, "light"),
+            "point_light": (PointLight, "light"),
+            "spot_light": (SpotLight, "light"),
+            "ambient": (AmbientLight, "light"),
+            "hemisphere": (HemisphereLight, "light"),
+            "line": (Line, "line"),
+            "figure": (Figure, "figure"),
         }
 
-        entity_cls, ent_type = mapping.get(entity_type, (Box, 'shape'))
+        entity_cls, ent_type = mapping.get(entity_type, (Box, "shape"))
         entity = entity_cls(*args, **kwargs)
         entity.entity_list_append(entity, ent_type)
         entity.name = entity.get_name(ent_type)

--- a/domains/web_to_3d.py
+++ b/domains/web_to_3d.py
@@ -2,49 +2,49 @@ import requests
 from bs4 import BeautifulSoup
 from domains.entity_class import Entity_fabric as ef
 from domains.entity_class import Entity
-from domains.model_class import ModelFabric as mf
 from domains.model_class import Model
-from domains.arch_class import ArchFabric as af
 from domains.arch_class import Arch
 import json
 import random
 import re
+
 
 def fetch_html(url):
     response = requests.get(url)
     response.raise_for_status()
     return response.text
 
+
 TAG_MAP = {
-    'h1': {'color': 0x0033cc},
-    'h2': {'color': 0x3366cc},
-    'h3': {'color': 0x6699ff},
-    'p':  {'color': 0x00aa88},
-    'div': {'color': 0x888888},
-    'a': {'color': 0xff5500},
-    'span': {'color': 0x55ffaa},
-    'button': {'color': 0xcc4444},
-    'input': {'color': 0xaaaaaa},
-    'img': {'color': 0xffffff}
+    "h1": {"color": 0x0033CC},
+    "h2": {"color": 0x3366CC},
+    "h3": {"color": 0x6699FF},
+    "p": {"color": 0x00AA88},
+    "div": {"color": 0x888888},
+    "a": {"color": 0xFF5500},
+    "span": {"color": 0x55FFAA},
+    "button": {"color": 0xCC4444},
+    "input": {"color": 0xAAAAAA},
+    "img": {"color": 0xFFFFFF},
 }
+
 
 def extract_size_from_style(style: str):
     """Парсинг width/height из inline-стиля"""
     width, height = 10, 2  # Значения по умолчанию
     if style:
-        w_match = re.search(r'width:\s*(\d+)px', style)
-        h_match = re.search(r'height:\s*(\d+)px', style)
+        w_match = re.search(r"width:\s*(\d+)px", style)
+        h_match = re.search(r"height:\s*(\d+)px", style)
         if w_match:
             width = max(1, int(w_match.group(1)) / 10)  # нормализация
         if h_match:
             height = max(1, int(h_match.group(1)) / 10)
     return width, height
 
-def parse_and_create_3d_elements(html):
-    from domains.entity_class import Entity_fabric as ef
-    from domains.entity_class import Entity
 
-    soup = BeautifulSoup(html, 'html.parser')
+def parse_and_create_3d_elements(html):
+
+    soup = BeautifulSoup(html, "html.parser")
     grid_x = 0
     grid_y = 0
     spacing = 5
@@ -66,53 +66,68 @@ def parse_and_create_3d_elements(html):
         width = 30  # можно сделать глубину фиксированной
 
         position = {
-            'x': (grid_x % 5) * (width + spacing),
-            'y': -(grid_y // 5) * (height + spacing),
-            'z': 0
+            "x": (grid_x % 5) * (width + spacing),
+            "y": -(grid_y // 5) * (height + spacing),
+            "z": 0,
         }
 
-        color = TAG_MAP.get(tag_name, {}).get('color', random.randint(0x111111, 0xffffff))
+        color = TAG_MAP.get(tag_name, {}).get(
+            "color", random.randint(0x111111, 0xFFFFFF)
+        )
+
+        text_value = tag.get_text(strip=True)
+        if text_value:
+            ef.create(
+                "text3d",
+                text=text_value,
+                size=3,
+                height=1,
+                position=position,
+                color=color,
+            )
 
         ef.create(
-            'box',
+            "box",
             width=width,
             height=height,
             depth=depth,
             position=position,
-            color=color
+            color=color,
         )
 
         grid_x += 1
         grid_y += 1
 
     # Debug: показать сколько сущностей создано
-    shapes = Entity.manager.get_entity_list('shape')
+    shapes = Entity.manager.get_entity_list("shape")
     print(f"[DEBUG] Total 3D shapes generated: {len(shapes)}")
+
 
 def export_to_dict():
     return {
-        'light': {
+        "light": {
             light.name: light.return_dict()
-            for light in Entity.manager.get_entity_list('light')
+            for light in Entity.manager.get_entity_list("light")
         },
-        'shape': {
+        "shape": {
             entity.name: entity.return_dict()
-            for entity in Entity.manager.get_entity_list('shape')
+            for entity in Entity.manager.get_entity_list("shape")
         },
-        'model': {
+        "model": {
             model.name: model.return_dict()
-            for model in Model.manager.get_model_list('model_obj')
+            for model in Model.manager.get_model_list("model_obj")
         },
-        'arch': {
-            arch.name: arch.return_dict()
-            for arch in Arch.manager.get_arch_list('arch')
-        }
+        "arch": {
+            arch.name: arch.return_dict() for arch in Arch.manager.get_arch_list("arch")
+        },
     }
 
-def convert_webpage_to_3d(url='https://www.google.ru'):
+
+def convert_webpage_to_3d(url="https://www.google.ru"):
     html = fetch_html(url)
     parse_and_create_3d_elements(html)
     return export_to_dict()
+
 
 if __name__ == "__main__":
     scene_data = convert_webpage_to_3d()


### PR DESCRIPTION
## Summary
- implement `Text3D` entity for 3D text
- wire `text3d` type into `Entity_fabric`
- generate `Text3D` in webpage conversion
- clean unused imports and format code

## Testing
- `ruff domains/entity_class.py domains/web_to_3d.py`
- `python3 -m domains.web_to_3d` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685c4d9b3f4c833281b4541d2ee6ce84