### PR TITLE
Fix handling of websocket disconnections

### DIFF
--- a/lib/websocket_server.py
+++ b/lib/websocket_server.py
@@ -99,6 +99,11 @@ async def echo_messages(websocket, path):
             except websockets.ConnectionClosedOK:
                 print(f"Client {websocket.remote_address} disconnected.")
                 break
+            except websockets.ConnectionClosedError as e:
+                print(
+                    f"Client {websocket.remote_address} disconnected with error: {e}"
+                )
+                break
             except Exception as e:
                 print(f"Error processing message from client: {e}")
                 continue


### PR DESCRIPTION
## Summary
- handle `ConnectionClosedError` so websocket server shuts down connections cleanly

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685c5dcf1f1483328b324fbe2ed8d042