### PR TITLE
Fix modules to use local Three.js

### DIFF
--- a/src/static/js/FontLoader.js
+++ b/src/static/js/FontLoader.js
@@ -2,7 +2,7 @@ import {
 	FileLoader,
 	Loader,
 	ShapePath
-} from 'three';
+} from './three.module.js';
 
 class FontLoader extends Loader {
 

--- a/src/static/js/TextGeometry.js
+++ b/src/static/js/TextGeometry.js
@@ -17,7 +17,7 @@
 
 import {
 	ExtrudeGeometry
-} from 'three';
+} from './three.module.js';
 
 class TextGeometry extends ExtrudeGeometry {
 


### PR DESCRIPTION
## Summary
- import FontLoader and TextGeometry from local `three.module.js`

## Testing
- `node src/templates/core/modeller.js` *(fails: Unexpected token from templating placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_6862f620de34833293e221c8a9a8d78e